### PR TITLE
이미지 변환시 충분한 메모리를 확보할 수 있게 한다.

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -1,5 +1,6 @@
 <?php
 namespace Xpressengine\Plugins\Importer;
+ini_set('memory_limit', '384M');
 
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Database\Schema\Blueprint;


### PR DESCRIPTION
이미지 변환시 충분한 메모리를 확보하여 메모리 제한에 걸리지 않도록 한다.
대부분의 서버가 512M 는 지원하는 것으로 가정하고 기본 128M 의 제한에 추가 256M 의 메모리를 사용할 수 있게 변경하였음